### PR TITLE
NAVER APP의 CSS 개선

### DIFF
--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -23,6 +23,13 @@
   }
 }
 
+/* NAVER APP */
+@media screen and (max-width: calc(768px - 1px)) {
+  .sm-hidden {
+    display: none !important;
+  }
+}
+
 @media screen and (max-width: calc(48rem - 1px)) {
   .sm-hidden {
     display: none !important;


### PR DESCRIPTION
# PR 설명
NAVER APP에서  `max-width: calc(48rem - 1px)`  제대로 적용되지 않아서, 레이아웃이 망가지는 현상 수정

# 작업 내용
- `max-width: calc(768px - 1px)` 미디어 쿼리 추가