### PR TITLE
subCategoryTab 클릭 시, scroll 버그 수정

### DIFF
--- a/src/components/common/TapPanel/TapPanel.tsx
+++ b/src/components/common/TapPanel/TapPanel.tsx
@@ -12,7 +12,8 @@ type Props = {
 
 export default function TabPanel({ title }: Props) {
   const headRef = useRef<HTMLHeadingElement>(null);
-  const { tabLable, scrollToTabPanel, savePanelPosition } = useTabScroll();
+  const { tabLable, scrollToTabPanel, savePanelPosition, clearTabLable } =
+    useTabScroll();
   const { youtubeToggle } = useYoutube();
 
   const throttleHandler = useMemo(
@@ -34,7 +35,11 @@ export default function TabPanel({ title }: Props) {
       const position = headRef.current?.getBoundingClientRect().top;
       scrollToTabPanel(position ?? 0);
     }
-  }, [tabLable, title, scrollToTabPanel]);
+
+    return () => {
+      clearTabLable();
+    };
+  }, [tabLable, title, scrollToTabPanel, clearTabLable]);
 
   useEffect(() => {
     detectTabPanelPositon();

--- a/src/recoil/SubCategoryTab/useTabScroll.tsx
+++ b/src/recoil/SubCategoryTab/useTabScroll.tsx
@@ -13,6 +13,8 @@ export default function useTabScroll() {
     setTabLabel(e.currentTarget.getAttribute('aria-labelledby') || '');
   };
 
+  const clearTabLable = () => setTabLabel('');
+
   const scrollToTabPanel = (position: number) => {
     window.scrollBy({
       top: calcScrollAmount(position),
@@ -33,6 +35,7 @@ export default function useTabScroll() {
     tabLable,
     panelPosition,
     getTabLablledby,
+    clearTabLable,
     scrollToTabPanel,
     savePanelPosition,
   };


### PR DESCRIPTION
# PR 설명
subCategoryTab 클릭 후, youtube 영상 버튼을 누르면 직전에 눌렀던 sub category tab 위치로  스크롤 되는 오류 수정

# 작업 내용
- 이전 tab label 초기화 로직 추가
