### PR TITLE
브라우저가 inactive tab인 경우, timer 딜레이 수정

### DIFF
--- a/src/components/layout/TimerBar/Timer.tsx
+++ b/src/components/layout/TimerBar/Timer.tsx
@@ -20,16 +20,18 @@ export default function Timer({ timer }: Props) {
   });
 
   const handleStartTimer = useCallback(() => {
+    const startedAt = Date.now();
+
     intervalId.current = window.setInterval(() => {
+      const elapsedTime = Math.floor((Date.now() - startedAt) / 1000);
       setClock({
-        min: time.current / 60,
-        sec: time.current % 60,
+        min: (time.current - elapsedTime) / 60,
+        sec: (time.current - elapsedTime) % 60,
       });
 
-      time.current--;
-
-      if (time.current < 0) {
+      if (time.current - elapsedTime < 0) {
         clearInterval(intervalId.current);
+        time.current = 0;
         setClock({ min: 0, sec: 0 });
       }
     }, 1000);
@@ -47,7 +49,9 @@ export default function Timer({ timer }: Props) {
   }, [handleStartTimer]);
 
   return (
-    <li className={`${styles.timer} ${time.current < 0 && styles['is-alarm']}`}>
+    <li
+      className={`${styles.timer} ${time.current <= 0 && styles['is-alarm']}`}
+    >
       <div className={styles.info}>
         <div className={styles['image-wrap']}>
           <Image


### PR DESCRIPTION
# PR 설명
브라우저가 inactive tab인 경우, setInterval 기능의 동작 우선순위가 내려가기 때문에 timer의 딜레이가 발생

# 작업 내용
- timer 시간 계산 로직 변경
