### PR TITLE
subcategory tab의 active 상태가 변하는 scroll 위치 변경

### DIFF
--- a/src/components/CategoryPage/TabScrollEvent/TabScrollEvent.tsx
+++ b/src/components/CategoryPage/TabScrollEvent/TabScrollEvent.tsx
@@ -15,7 +15,7 @@ export default function TabScrollEvent() {
   const throttleHandler = useMemo(
     () =>
       throttle(() => {
-        const scrolledAmount = calcScrollAmount(window.scrollY + 10, 'user');
+        const scrolledAmount = calcScrollAmount(window.scrollY + 40, 'user');
         const newActiveTab = tabByCategory(
           pathname.split('/')[2],
           scrolledAmount,


### PR DESCRIPTION
# PR 설명
이전 subcategory tab의 설명 영역이 지나면, tab active 상태가 바뀌도록 scroll 위치 변경

# 작업 내용
- scroll 위치 변경
