### PR TITLE
fix: 검색 후, 해당 몬스터로 스크롤되지 않는 오류 수정

### DIFF
--- a/src/components/common/MonsterCard/index.tsx
+++ b/src/components/common/MonsterCard/index.tsx
@@ -17,7 +17,7 @@ export default function MonsterCard({ monster }: Props) {
   const search = sesarchParams.get('search');
 
   useEffect(() => {
-    if (cardRef.current?.innerText === search) {
+    if (cardRef.current?.dataset.monsterName === search) {
       const position = cardRef.current.getBoundingClientRect().top;
 
       window.scrollBy({
@@ -32,6 +32,7 @@ export default function MonsterCard({ monster }: Props) {
       ref={cardRef}
       data-tooltip-id='monster-tooltip' // <MonsterToolTip /> 컴포넌트와 연결
       data-tooltip-content={monster.name}
+      data-monster-name={monster.name}
     >
       <div className={styles['image-wrap']}>
         <Image


### PR DESCRIPTION
# PR 설명
- 검색 후, 해당 몬스터로 스크롤되지 않는 오류 수정

# 작업 내용
- 기존
   - 몬스터 카드 element의 innerText 값과 검색 키워드를 비교
- 변경
   - 몬스터 카드 element의 dataset(monster-name)값과 검색 키워드를 비교
