### PR TITLE
style: SideCategoryNav 스타일 변경

### DIFF
--- a/src/components/common/CategoryCard/css/index.module.css
+++ b/src/components/common/CategoryCard/css/index.module.css
@@ -14,6 +14,10 @@
   background-color: var(--color-border);
 }
 
+.card.is-active:has(.title.title-hidden) {
+  background-color: rgba(154, 98, 230, 0.4);
+}
+
 .card.is-active .title {
   color: var(--color-brand);
 }

--- a/src/components/common/CategoryCard/css/index.module.css
+++ b/src/components/common/CategoryCard/css/index.module.css
@@ -65,7 +65,7 @@
   color: var(--color-font);
   visibility: visible;
   opacity: 1;
-  transition: opacity 0.3s ease, visibility 0.3s ease;
+  transition: opacity 0.4s ease, visibility 0.4s ease;
 }
 
 .title.title-hidden {

--- a/src/components/common/CategoryCard/index.tsx
+++ b/src/components/common/CategoryCard/index.tsx
@@ -11,9 +11,6 @@ type Props = {
   imgSize?: 'small' | 'normal';
   isTitleVisible?: boolean;
   onToggleSideBar?: () => void;
-
-  /** SideCategoyNav 컴포넌트의 linePosition 상태 변경 */
-  onSetLinePosition?: (position: number) => void;
 };
 
 export default function CategoryCard({
@@ -21,7 +18,7 @@ export default function CategoryCard({
   imgSize = 'normal',
   isTitleVisible = true,
   onToggleSideBar,
-  onSetLinePosition,
+
   ...tooltipOptions
 }: Props) {
   const pathname = usePathname();
@@ -29,15 +26,6 @@ export default function CategoryCard({
   const handleClick = () => {
     onToggleSideBar && onToggleSideBar();
   };
-
-  /** 첫 렌더링 시, 현재 경로에 해당하는 card로 vertical line 위치 설정 */
-  useEffect(() => {
-    if (!onSetLinePosition) return;
-
-    if (pathname.split('/')[2] === path && cardRef.current) {
-      onSetLinePosition(cardRef.current.offsetTop);
-    }
-  }, [pathname]);
 
   return (
     <>

--- a/src/components/common/CategoryCard/index.tsx
+++ b/src/components/common/CategoryCard/index.tsx
@@ -4,7 +4,6 @@ import Image from 'next/image';
 import Link from 'next/link';
 import styles from './css/index.module.css';
 import { usePathname } from 'next/navigation';
-import { useEffect, useRef } from 'react';
 
 type Props = {
   category: MainCategory;
@@ -18,11 +17,9 @@ export default function CategoryCard({
   imgSize = 'normal',
   isTitleVisible = true,
   onToggleSideBar,
-
   ...tooltipOptions
 }: Props) {
   const pathname = usePathname();
-  const cardRef = useRef<HTMLAnchorElement>(null);
   const handleClick = () => {
     onToggleSideBar && onToggleSideBar();
   };
@@ -36,7 +33,6 @@ export default function CategoryCard({
         href={`/category/${path}`}
         prefetch={false}
         onClick={handleClick}
-        ref={cardRef}
         {...tooltipOptions}
       >
         <div className={styles.img}>

--- a/src/components/layout/SideCategoryNav/css/index.module.css
+++ b/src/components/layout/SideCategoryNav/css/index.module.css
@@ -14,7 +14,6 @@
   border: 1px solid var(--color-border);
   border-radius: 0.5rem;
   box-shadow: var(--shadow-lg);
-  transition: width 0.5s ease;
 }
 
 .list {
@@ -52,7 +51,7 @@
   color: var(--color-white);
   background-color: var(--color-blue);
   border-radius: 0.5rem;
-  transition: all 0.5s;
+  transition: transform 0.5s;
   transform: translateX(-50%) rotate(180deg);
 }
 

--- a/src/components/layout/SideCategoryNav/css/index.module.css
+++ b/src/components/layout/SideCategoryNav/css/index.module.css
@@ -42,18 +42,6 @@
   margin: 0.25rem 0;
 }
 
-.vertical-line {
-  position: absolute;
-  top: 0.5rem;
-  width: 0.25rem;
-  height: 1.8rem;
-  background-color: var(--color-brand);
-  border-radius: 100px;
-  opacity: 0;
-  transition: transform 0.2s linear,
-    opacity 0.8s cubic-bezier(1, 0.04, 1, -0.43);
-}
-
 .toggle-button {
   position: absolute;
   left: 50%;

--- a/src/components/layout/SideCategoryNav/index.tsx
+++ b/src/components/layout/SideCategoryNav/index.tsx
@@ -3,7 +3,6 @@ import { MainCategory } from '@/model/category';
 import CategoryCard from '../../common/CategoryCard';
 import styles from './css/index.module.css';
 import ArrowBarIcon from '../../common/icons/ArrowBarIcon';
-import { useRef } from 'react';
 import useSideCategoryNav from '@/recoil/SideCategoryNav/useSideCategoryNav';
 import Tooltip from '@/components/common/Tooltip';
 
@@ -13,13 +12,9 @@ type Props = {
 
 export default function SideCategoryNav({ categories }: Props) {
   const [isOpen, handleSideCategoryNavToggle] = useSideCategoryNav();
-  const navRef = useRef<HTMLElement>(null);
 
   return (
-    <nav
-      className={`sm-hidden ${styles.nav} ${isOpen && styles['is-open']}`}
-      ref={navRef}
-    >
+    <nav className={`sm-hidden ${styles.nav} ${isOpen && styles['is-open']}`}>
       <button
         type='button'
         className={styles['toggle-button']}

--- a/src/components/layout/SideCategoryNav/index.tsx
+++ b/src/components/layout/SideCategoryNav/index.tsx
@@ -3,9 +3,7 @@ import { MainCategory } from '@/model/category';
 import CategoryCard from '../../common/CategoryCard';
 import styles from './css/index.module.css';
 import ArrowBarIcon from '../../common/icons/ArrowBarIcon';
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { throttle } from 'lodash';
-import { usePathname } from 'next/navigation';
+import { useRef } from 'react';
 import useSideCategoryNav from '@/recoil/SideCategoryNav/useSideCategoryNav';
 import Tooltip from '@/components/common/Tooltip';
 
@@ -14,48 +12,8 @@ type Props = {
 };
 
 export default function SideCategoryNav({ categories }: Props) {
-  const pathname = usePathname();
   const [isOpen, handleSideCategoryNavToggle] = useSideCategoryNav();
-  const [linePosition, setLinePosition] = useState<number | null>(null); // 첫 렌더링 시, 현재 경로에 해당하는 vertical line의 y position
   const navRef = useRef<HTMLElement>(null);
-  const verticalLineRef = useRef<HTMLDivElement>(null);
-
-  /** 클릭한 category item으로 vertical line 위치 조정 */
-  const handleVerticalLineClick = (e: React.MouseEvent<HTMLLIElement>) => {
-    const lineElment = verticalLineRef.current;
-
-    if (lineElment) {
-      lineElment.style.transform = `translateY(${e.currentTarget.offsetTop}px)`;
-      lineElment.style.opacity = '1';
-    }
-  };
-
-  /** 첫 렌더링 시, 현재 경로에 해당하는 category item으로 vertical line 위치 설정 */
-  useEffect(() => {
-    const lineElment = verticalLineRef.current;
-
-    if (lineElment && linePosition) {
-      lineElment.style.transform = `translateY(${linePosition}px)`;
-      lineElment.style.opacity = '1';
-    }
-  }, [linePosition]);
-
-  const throttleHandler = useMemo(
-    () =>
-      throttle(() => {
-        const lineElment = verticalLineRef.current;
-        if (window.matchMedia('(max-width: 48rem)').matches && lineElment) {
-          lineElment.style.opacity = '0';
-        }
-      }, 700),
-    []
-  );
-
-  /** 모바일 사이즈로 변경 시, verticalLine을 숨김 처리 */
-  useEffect(() => {
-    window.addEventListener('resize', throttleHandler);
-    return () => window.removeEventListener('resize', throttleHandler);
-  }, [throttleHandler]);
 
   return (
     <nav
@@ -73,18 +31,11 @@ export default function SideCategoryNav({ categories }: Props) {
 
       <ol className={styles.list}>
         {categories.map((category) => (
-          <li
-            className={styles.item}
-            key={category.path}
-            onClick={(e: React.MouseEvent<HTMLLIElement>) =>
-              handleVerticalLineClick(e)
-            }
-          >
+          <li className={styles.item} key={category.path}>
             <CategoryCard
               category={category}
               imgSize='small'
               isTitleVisible={isOpen}
-              onSetLinePosition={setLinePosition}
               data-tooltip-id='category-tooltip'
               data-tooltip-content={category.title}
             />
@@ -96,13 +47,6 @@ export default function SideCategoryNav({ categories }: Props) {
           hidden={isOpen}
           place='right'
           positionStrategy='fixed'
-        />
-
-        <div
-          className={`${
-            pathname.split('/')[1] === 'category' && styles['vertical-line']
-          }`}
-          ref={verticalLineRef}
         />
       </ol>
     </nav>

--- a/src/components/routes/category/layout/TableOfContents/index.tsx
+++ b/src/components/routes/category/layout/TableOfContents/index.tsx
@@ -102,9 +102,7 @@ export default function TableOfContents({ subCategories }: Props) {
   useEffect(saveHeadingPosition, [youtubeToggle, saveHeadingPosition]);
 
   /** sideCategoryNav 토글 시, TOCHeading 위치 재설정 */
-  useEffect(() => {
-    setTimeout(saveHeadingPosition, 530); // css transition이 끝난 뒤, 실행
-  }, [isSideCategoryNavOpen, saveHeadingPosition]);
+  useEffect(saveHeadingPosition, [isSideCategoryNavOpen, saveHeadingPosition]);
 
   /** 모바일 toc의 가로스크롤을 위해 tocItem Elements를 저장 */
   const SaveTocItemPositionForMobile = useMemo(


### PR DESCRIPTION
# PR 설명
SideCategoryNav 스타일 변경

# 작업 내용
- desktop 사이즈에서 현재 카테고리 경로를 나타내는 vertical line 스타일 제거
- SideCategoryNav의 width transtion 효과 제거
- SideCategoryNav가 접혔을 때, CategoryCard의 is-active 배경색 변경
