### PR TITLE
feat: 몬스터 검색 페이지 스크롤 로직 개선

### DIFF
--- a/src/components/common/MonsterCard/index.tsx
+++ b/src/components/common/MonsterCard/index.tsx
@@ -3,9 +3,7 @@ import { Monster } from '@/model/monster';
 import Image from 'next/image';
 import styles from './css/index.module.css';
 import Bookmark from './Bookmark';
-import { useEffect, useRef } from 'react';
 import { useSearchParams } from 'next/navigation';
-import calcScrollAmount from '@/utils/calcScrollAmount';
 import imageEncodeURI from '@/utils/imageEncodeURI';
 
 type Props = {
@@ -13,25 +11,13 @@ type Props = {
 };
 
 export default function MonsterCard({ monster }: Props) {
-  const cardRef = useRef<HTMLDivElement | null>(null);
   const sesarchParams = useSearchParams();
   const search = sesarchParams.get('search');
   const encodeName = imageEncodeURI(monster.name);
 
-  useEffect(() => {
-    if (cardRef.current?.dataset.monsterName === search) {
-      const position = cardRef.current.getBoundingClientRect().top;
-
-      window.scrollBy({
-        top: calcScrollAmount(position),
-      });
-    }
-  }, [search]);
-
   return (
     <div
       className={`${styles.card} ${search === monster.name && styles.target}`}
-      ref={cardRef}
       data-tooltip-id='monster-tooltip' // <MonsterToolTip /> 컴포넌트와 연결
       data-tooltip-content={monster.name}
       data-monster-name={monster.name}

--- a/src/components/common/Search/hooks/useSearch.tsx
+++ b/src/components/common/Search/hooks/useSearch.tsx
@@ -1,4 +1,5 @@
 import { SearchMonster } from '@/model/monster';
+import calcScrollAmount from '@/utils/calcScrollAmount';
 import { useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
@@ -167,6 +168,22 @@ export default function useSearch(monsters: SearchMonster[]) {
       setText(searchParam);
       setKeyword(searchParam);
       setSelected(selectedMonster);
+    }
+  }, [searchParams]);
+
+  /** 검색한 몬스터 위치로 페이지 스크롤 */
+  useEffect(() => {
+    const searchParam = searchParams.get('search');
+    const cardNodeList = document.querySelectorAll(
+      `[data-monster-name='${searchParam}']`
+    );
+
+    if (cardNodeList.length >= 1) {
+      const position = cardNodeList[0].getBoundingClientRect().top;
+
+      window.scrollBy({
+        top: calcScrollAmount(position),
+      });
     }
   }, [searchParams]);
 


### PR DESCRIPTION
# PR 설명
몬스터 검색 페이지 스크롤 로직 개선
- `기존` 페이지 내 검색된 몬스터가 2개 이상 존재하는 경우, 마지막 몬스터 카드 위치로 스크롤
- `변경` 첫 번째 카드 위치로 스크롤 되도록 개선

# 작업 내용
- `MonsterCard` 컴포넌트에서 `useSearch` hook으로 로직 위치 변경
- 첫 번째 카드 위치로 스크롤 되도록 개선

# Screenshot
| 기존 | 변경 |
| --- | --- |
| ![image](https://github.com/presentKey/next-monster-colletion/assets/115006670/8e2884bb-edb4-4d24-a2b0-55de26f76d9c) | ![image](https://github.com/presentKey/next-monster-colletion/assets/115006670/599298e5-4bd2-4d04-9b99-dd6730a643cf) |